### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/web/server/package.json
+++ b/web/server/package.json
@@ -22,6 +22,7 @@
     "nodemon": "^3.1.9",
     "prisma": "^6.6.0",
     "uuid": "^11.1.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/web/server/src/routes/authRoutes.js
+++ b/web/server/src/routes/authRoutes.js
@@ -1,14 +1,20 @@
 import express from 'express'
 import { register, login, validateToken } from '../controllers/authController.js'
 import { authMiddleware } from '../middleware/auth.js'
+import RateLimit from 'express-rate-limit'
 
 const router = express.Router()
+
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
 
 // public routes
 router.post('/register', register)
 router.post('/login', login)
 
 // protected routes
-router.get('/validate', authMiddleware, validateToken)
+router.get('/validate', limiter, authMiddleware, validateToken)
 
 export default router


### PR DESCRIPTION
Potential fix for [https://github.com/AshenDulsanka/PUSL-3190-Phisher/security/code-scanning/3](https://github.com/AshenDulsanka/PUSL-3190-Phisher/security/code-scanning/3)

To fix the problem, we need to introduce rate limiting to the route handler that performs authorization. The best way to achieve this is by using the `express-rate-limit` package, which allows us to easily set up and apply rate limiting to specific routes.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `authRoutes.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the route handler that performs authorization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
